### PR TITLE
Mention filename once when generating proselint config

### DIFF
--- a/.github/workflows/proselint.yml
+++ b/.github/workflows/proselint.yml
@@ -25,13 +25,15 @@ jobs:
     # config file help: https://github.com/amperser/proselint/
     - name: store proselint config
       run: |
-        echo '{' > $HOME/.proselintrc
-        echo '   "checks": {' >> $HOME/.proselintrc
-        echo '     "typography.diacritical_marks": false,' >> $HOME/.proselintrc
-        echo '     "typography.symbols": false,' >> $HOME/.proselintrc
-        echo '     "annotations.misc": false' >> $HOME/.proselintrc
-        echo '   }' >> $HOME/.proselintrc
-        echo '}' >> $HOME/.proselintrc
+        {
+          echo '{'
+          echo '   "checks": {'
+          echo '     "typography.diacritical_marks": false,'
+          echo '     "typography.symbols": false,'
+          echo '     "annotations.misc": false'
+          echo '   }'
+          echo '}'
+        } > $HOME/.proselintrc
 
     - name: check prose
       run: make proselint


### PR DESCRIPTION
Less clutter and should be easier to maintain.